### PR TITLE
Create undo and redo symbols once

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Tiny module for [Storeon] which is adding undo functionality to your state. This means that now you can undoing or redoing the events in the state.
 
-It is just 364 bytes module (it uses [Size Limit] to control the size) without any dependencies.
+It is just 360 bytes module (it uses [Size Limit] to control the size) without any dependencies.
 
 [Size Limit]: https://github.com/ai/size-limit
 [Storeon]: https://github.com/storeon/storeon

--- a/index.js
+++ b/index.js
@@ -10,16 +10,12 @@ let createHistory = function (paths) {
     )
   }
 
-  let undo = Symbol('u')
-  let redo = Symbol('r')
-
   let key = 'undoable'
   if (paths.length > 0) {
-    undo = Symbol('u_' + paths.join('_'))
-    redo = Symbol('r_' + paths.join('_'))
-
     key += '_' + paths.join('_')
   }
+  let undo = Symbol('u_' + key)
+  let redo = Symbol('r_' + key)
 
   return {
     module (store) {

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "329 B"
+      "limit": "325 B"
     },
     {
       "path": "full/index.js",
-      "limit": "364 B"
+      "limit": "360 B"
     }
   ],
   "eslintConfig": {


### PR DESCRIPTION
* looks a bit better (subjectively) without multiple `paths.join` and overwriting of defined symbols
* probably works a tiny smidge faster without multiple `paths.join` and `Symbol` if `paths` is not empty
    * but definitely a bit slower if `paths` is empty as there are now string concatenation 
* provides better description for default symbols
* a bit smaller code
* will break code for somebody who relied on `UNDO.toString()` or `REDO.toString()`