### PR TITLE
Provide ability to configure state key for history storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Tiny module for [Storeon] which is adding undo functionality to your state. This means that now you can undoing or redoing the events in the state.
 
-It is just 360 bytes module (it uses [Size Limit] to control the size) without any dependencies.
+It is just 375 bytes module (it uses [Size Limit] to control the size) without any dependencies.
 
 [Size Limit]: https://github.com/ai/size-limit
 [Storeon]: https://github.com/storeon/storeon
@@ -108,6 +108,28 @@ dispatch(UNDO)
 ```
 
 ![Example of history only for specific key](example_history.gif)
+
+### API
+
+#### createHistory(paths, config)
+
+##### paths parameter
+
+```js
+type paths = Array<String>
+```
+
+The keys of state object that will be stored in history
+
+##### config parameter
+
+```js
+type config.key = String
+```
+
+The default state key for storing history, when omitted:
+* if `paths` is not empty will be generated based on `paths` content
+* otherwise will default to `'undoable'`
 
 ## LICENSE
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,23 @@
 import { StoreonModule } from 'storeon'
 
+declare namespace StoreonUndo {
+  export interface Config {
+    key?: string;
+  }
+}
+
 /**
  * Storeon module to add undo and redo functionality
  * @param {String[]} paths The keys of state object
  *    that will be store in history
+ * @param {Object} config The config object
+ * @param {String} [config.key='undoable'] The default state key
+ *    for storing history (when omitted and `paths` is not empty
+ *    will be generated based on `paths` content)
  */
 declare function createHistory<State>(
-	paths: String[]
+	paths: String[],
+	config?: StoreonUndo.Config
 ): {
 	module: StoreonModule<State>,
     UNDO: Symbol,

--- a/index.js
+++ b/index.js
@@ -2,16 +2,21 @@
  * Storeon module to add undo and redo functionality
  * @param {String[]} paths The keys of state object
  *    that will be store in history
+ * @param {Object} config The config object
+ * @param {String} [config.key='undoable'] The default state key
+ *    for storing history (when omitted and `paths` is not empty
+ *    will be generated based on `paths` content)
  */
-let createHistory = function (paths) {
+let createHistory = function (paths, config) {
   if (process.env.NODE_ENV === 'development' && !paths) {
     throw new Error(
       'The paths parameter should be an array: createHistory([])'
     )
   }
+  config = config || {}
 
-  let key = 'undoable'
-  if (paths.length > 0) {
+  let key = config.key || 'undoable'
+  if (!config.key && paths.length > 0) {
     key += '_' + paths.join('_')
   }
   let undo = Symbol('u_' + key)

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "325 B"
+      "limit": "339 B"
     },
     {
       "path": "full/index.js",
-      "limit": "360 B"
+      "limit": "375 B"
     }
   ],
   "eslintConfig": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -68,6 +68,42 @@ it('should create separeted history for key', () => {
   })
 })
 
+it('should use key provided in config when paths is empty', () => {
+  let history = createHistory([], { key: 'testKey' })
+
+  let str = createStoreon([freezer, counter, history.module])
+
+  str.dispatch('counter/add')
+
+  expect(str.get()).toEqual({
+    a: 1,
+    b: 1,
+    testKey: {
+      future: [],
+      past: [{ a: 0, b: 0 }],
+      present: { a: 1, b: 1 }
+    }
+  })
+})
+
+it('should use key provided in config when paths is not empty', () => {
+  let history = createHistory(['a'], { key: 'testKey' })
+
+  let str = createStoreon([freezer, counter, history.module])
+
+  str.dispatch('counter/add')
+
+  expect(str.get()).toEqual({
+    a: 1,
+    b: 1,
+    testKey: {
+      future: [],
+      past: [{ a: 0 }],
+      present: { a: 1 }
+    }
+  })
+})
+
 it('undo with separeted history should revert only provided key', () => {
   let history = createHistory(['a'])
 


### PR DESCRIPTION
Hello

I propose (with code) to make state history key configurable.

The use case i had in mind:
```javascript
import { createHistory } from '@storeon/undo'
import { persistState } from '@storeon/localstorage'

const FORM_HISTORY_KEY = 'formHistory'

let keysForHistory = ['caption', 'text']
let history = createHistory(keysForHistory, { key: FORM_HISTORY_KEY })

let keysToPersist = [...keysForHistory, FORM_HISTORY_KEY]
let persist = persistState(keysToPersist)
```
With key configuration you don't have to rely on how key generated for your `paths` and don't need to change it every time you change keys of `keysForHistory` (or add new keys)

---

Another option is to expose key instead of this pull request and then users will be able to access generated key:
```javascript
import { createHistory } from '@storeon/undo'
import { persistState } from '@storeon/localstorage'

let keysForHistory = ['caption', 'text']
let history = createHistory(keysForHistory)

let keysToPersist = [...keysForHistory, history.key]
let persist = persistState(keysToPersist)
```
But if `keysForHistory` is ever changed then `history.key` will differ to the key used in localStorage state.

---

Also if this pull request merged AND key is exposed then user can do:
```javascript
import { createHistory } from '@storeon/undo'
import { persistState } from '@storeon/localstorage'

let keysForHistory = ['caption', 'text']
let history = createHistory(keysForHistory, { key: 'formHistory' })

let keysToPersist = [...keysForHistory, history.key]
let persist = persistState(keysToPersist)
```

---

I did key exposure and can make pull request if needed: https://github.com/storeon/undo/compare/master...rndr:expose_key