### PR TITLE
Updated '@changed' listener

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,11 +42,11 @@ let createHistory = function (paths, config) {
         }
 
         if (paths.length) {
-          const changedKeys = Object.keys(changes)
+          let changedKeys = Object.keys(changes)
           let inPaths = false
 
           for (let changedKey of changedKeys) {
-            if (paths.indexOf(changedKey) > -1) {
+            if (paths.includes(changedKey)) {
               inPaths = true
               break
             }

--- a/index.js
+++ b/index.js
@@ -35,10 +35,26 @@ let createHistory = function (paths, config) {
         }
       })
 
-      store.on('@changed', state => {
+      store.on('@changed', (state, changes) => {
         if (ignoreNext) {
           ignoreNext = false
           return
+        }
+
+        if (paths.length) {
+          const changedKeys = Object.keys(changes)
+          let inPaths = false
+
+          for (let changedKey of changedKeys) {
+            if (paths.indexOf(changedKey) > -1) {
+              inPaths = true
+              break
+            }
+          }
+
+          if (!inPaths) {
+            return
+          }
         }
 
         ignoreNext = true

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
   "size-limit": [
     {
       "path": "index.js",
-      "limit": "339 B"
+      "limit": "395 B"
     },
     {
       "path": "full/index.js",
-      "limit": "377 B"
+      "limit": "430 B"
     }
   ],
   "eslintConfig": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -367,7 +367,7 @@ it('should not cause a redundant insertion into past key if change is done outsi
   expect(str.get()).toEqual({
     a: 0,
     b: 1,
-    testKey: {
+    undoable_a: {
       future: [],
       past: [],
       present: { a: 0 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,6 +31,12 @@ beforeEach(() => {
         b: state.b + 1
       }
     })
+
+    s.on('counter/add/b-only', state => {
+      return {
+        b: state.b + 1
+      }
+    })
   }
 
   store = createStoreon([freezer, counter, undoable])
@@ -50,7 +56,7 @@ it('should throw the error in production mode', () => {
   }).toThrow("Cannot read property 'length' of undefined")
 })
 
-it('should create separeted history for key', () => {
+it('should create separated history for key', () => {
   let history = createHistory(['a'])
 
   let str = createStoreon([freezer, counter, history.module])
@@ -104,7 +110,7 @@ it('should use key provided in config when paths is not empty', () => {
   })
 })
 
-it('undo with separeted history should revert only provided key', () => {
+it('undo with separated history should revert only provided key', () => {
   let history = createHistory(['a'])
 
   store = createStoreon([freezer, counter, history.module])
@@ -347,6 +353,24 @@ it('undo should do nothing if past is empty', () => {
       ],
       past: [],
       present: { a: 0, b: 0 }
+    }
+  })
+})
+
+it('should not cause a redundant insertion into past key if change is done outside paths', () => {
+  let history = createHistory(['a'])
+
+  let str = createStoreon([freezer, counter, history.module])
+
+  str.dispatch('counter/add/b-only')
+
+  expect(str.get()).toEqual({
+    a: 0,
+    b: 1,
+    testKey: {
+      future: [],
+      past: [],
+      present: { a: 0 }
     }
   })
 })


### PR DESCRIPTION
Updated @ changed listener to check if any changed key is in specific keys in paths or not. Otherwise, a @ changed event (no matter in paths or not) causes a redundant insertion into past key of undoable state.